### PR TITLE
Add initial unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,9 @@ jobs:
       - name: List downloaded artifacts
         run: tree datafusion-java/build/jni_libs
 
+      - name: Build and test
+        run: ./gradlew -PJNI_PATH=${{ github.workspace }}/datafusion-java/build/jni_libs/linux-x86_64 build
+
       - name: Publish to Maven Local
         run: ./gradlew publishToMavenLocal
 

--- a/datafusion-java/build.gradle
+++ b/datafusion-java/build.gradle
@@ -12,6 +12,11 @@ dependencies {
     implementation 'org.apache.arrow:arrow-format:13.0.0'
     implementation 'org.apache.arrow:arrow-vector:13.0.0'
     runtimeOnly 'org.apache.arrow:arrow-memory-unsafe:13.0.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.apache.hadoop:hadoop-client:3.3.5'
+    testImplementation 'org.apache.hadoop:hadoop-common:3.3.5'
+    testImplementation 'org.apache.parquet:parquet-avro:1.13.0'
+    testImplementation 'org.apache.parquet:parquet-hadoop:1.13.0'
 }
 
 spotless {
@@ -33,6 +38,12 @@ javadoc {
     if (JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
     }
+}
+
+test {
+    def libraryPath = findProperty("JNI_PATH") ?: "$rootDir/datafusion-java/build/jni_libs/dev"
+    jvmArgs += ["-Djava.library.path=$libraryPath", "--add-opens=java.base/java.nio=ALL-UNNAMED"]
+    useJUnitPlatform()
 }
 
 def cargoBinary = "${System.getProperty('user.home')}/.cargo/bin/cargo"

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/NativeProxy.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/NativeProxy.java
@@ -6,5 +6,10 @@ package org.apache.arrow.datafusion;
  */
 interface NativeProxy {
 
+  /**
+   * Get a pointer to the native object
+   *
+   * @return Pointer value as a long
+   */
   long getPointer();
 }

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/SessionContext.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/SessionContext.java
@@ -6,15 +6,36 @@ import java.util.concurrent.CompletableFuture;
 /** A session context holds resources and is the entrance for obtaining {@link DataFrame} */
 public interface SessionContext extends AutoCloseable, NativeProxy {
 
-  /** Obtain the {@link DataFrame} by running the {@code sql} against the datafusion library */
+  /**
+   * Obtain the {@link DataFrame} by running the {@code sql} against the datafusion library
+   *
+   * @param sql The query to execute
+   * @return DataFrame representing the query result
+   */
   CompletableFuture<DataFrame> sql(String sql);
 
-  /** Registering a csv file with the context */
+  /**
+   * Registering a csv file with the context
+   *
+   * @param name The table name to use to refer to the data
+   * @param path Path to the CSV file
+   * @return Future that is completed when the CSV is registered
+   */
   CompletableFuture<Void> registerCsv(String name, Path path);
 
-  /** Registering a parquet file with the context */
+  /**
+   * Registering a parquet file with the context
+   *
+   * @param name The table name to use to refer to the data
+   * @param path Path to the Parquet file
+   * @return Future that is completed when the Parquet file is registered
+   */
   CompletableFuture<Void> registerParquet(String name, Path path);
 
-  /** Get the runtime associated with this context */
+  /**
+   * Get the runtime associated with this context
+   *
+   * @return The context's runtime
+   */
   Runtime getRuntime();
 }

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/SessionContexts.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/SessionContexts.java
@@ -1,17 +1,33 @@
 package org.apache.arrow.datafusion;
 
+/** Manages session contexts */
 public class SessionContexts {
 
   private SessionContexts() {}
 
+  /**
+   * Create a new session context
+   *
+   * @return native pointer to the created session context
+   */
   static native long createSessionContext();
 
+  /**
+   * Destroy a session context
+   *
+   * @param pointer native pointer to the session context to destroy
+   */
   static native void destroySessionContext(long pointer);
 
   static {
     JNILoader.load();
   }
 
+  /**
+   * Create a new default session context
+   *
+   * @return The created context
+   */
   public static SessionContext create() {
     long pointer = createSessionContext();
     return new DefaultSessionContext(pointer);

--- a/datafusion-java/src/test/java/org/apache/arrow/datafusion/ParquetWriter.java
+++ b/datafusion-java/src/test/java/org/apache/arrow/datafusion/ParquetWriter.java
@@ -1,0 +1,41 @@
+package org.apache.arrow.datafusion;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.util.HadoopOutputFile;
+import org.apache.parquet.io.OutputFile;
+
+/** Helper class for writing test files in Parquet format using Avro records */
+public class ParquetWriter {
+  public static void writeParquet(
+      Path path, String schema, int rowCount, BiConsumer<Integer, GenericData.Record> setRecord)
+      throws IOException {
+    Configuration config = new Configuration();
+    org.apache.hadoop.fs.Path hadoopFilePath = new org.apache.hadoop.fs.Path(path.toString());
+    OutputFile outputFile = HadoopOutputFile.fromPath(hadoopFilePath, config);
+
+    Schema.Parser parser = new Schema.Parser().setValidate(true);
+    Schema avroSchema = parser.parse(schema);
+
+    try (org.apache.parquet.hadoop.ParquetWriter<GenericData.Record> writer =
+        AvroParquetWriter.<GenericData.Record>builder(outputFile)
+            .withSchema(avroSchema)
+            .withConf(config)
+            .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+            .withCompressionCodec(CompressionCodecName.SNAPPY)
+            .build()) {
+      for (int i = 0; i < rowCount; ++i) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        setRecord.accept(i, record);
+        writer.write(record);
+      }
+    }
+  }
+}

--- a/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestQuery.java
+++ b/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestQuery.java
@@ -1,0 +1,79 @@
+package org.apache.arrow.datafusion;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestQuery {
+  @Test
+  public void testQueryCsv(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path csvFilePath = tempDir.resolve("data.csv");
+
+      List<String> lines = Arrays.asList("x,y", "1,2", "3,4");
+      Files.write(csvFilePath, lines);
+
+      context.registerCsv("test", csvFilePath).join();
+      testQuery(context, allocator);
+    }
+  }
+
+  @Test
+  public void testQueryParquet(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path parquetFilePath = tempDir.resolve("data.parquet");
+
+      String schema =
+          "{\"namespace\": \"org.example\","
+              + "\"type\": \"record\","
+              + "\"name\": \"record_name\","
+              + "\"fields\": ["
+              + " {\"name\": \"x\", \"type\": \"long\"},"
+              + " {\"name\": \"y\", \"type\": \"long\"}"
+              + " ]}";
+
+      ParquetWriter.writeParquet(
+          parquetFilePath,
+          schema,
+          2,
+          (i, record) -> {
+            record.put("x", i * 2 + 1);
+            record.put("y", i * 2 + 2);
+          });
+
+      context.registerParquet("test", parquetFilePath).join();
+      testQuery(context, allocator);
+    }
+  }
+
+  private static void testQuery(SessionContext context, BufferAllocator allocator)
+      throws Exception {
+    try (ArrowReader reader =
+        context
+            .sql("SELECT y FROM test WHERE x = 3")
+            .thenComposeAsync(df -> df.collect(allocator))
+            .join()) {
+
+      VectorSchemaRoot root = reader.getVectorSchemaRoot();
+      assertTrue(reader.loadNextBatch());
+
+      assertEquals(1, root.getRowCount());
+      BigIntVector yValues = (BigIntVector) root.getVector(0);
+      assertEquals(4, yValues.get(0));
+
+      assertFalse(reader.loadNextBatch());
+    }
+  }
+}

--- a/datafusion-jni/src/dataframe.rs
+++ b/datafusion-jni/src/dataframe.rs
@@ -1,5 +1,6 @@
 use arrow::ipc::writer::FileWriter;
 use datafusion::dataframe::DataFrame;
+use datafusion::prelude::SessionContext;
 use jni::objects::{JClass, JObject, JString, JValue};
 use jni::sys::jlong;
 use jni::JNIEnv;
@@ -7,7 +8,6 @@ use std::convert::Into;
 use std::io::BufWriter;
 use std::io::Cursor;
 use std::sync::Arc;
-use datafusion::prelude::SessionContext;
 use tokio::runtime::Runtime;
 
 #[no_mangle]


### PR DESCRIPTION
This adds documentation comments to some methods to fix build warnings, and adds some initial basic unit tests for  querying CSV and Parquet files.