### PR TITLE
Factor out common error handling code in the jni library

### DIFF
--- a/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestQuery.java
+++ b/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestQuery.java
@@ -78,6 +78,16 @@ public class TestQuery {
     }
   }
 
+  @Test
+  public void testInvalidQuery() throws Exception {
+    try (SessionContext context = SessionContexts.create()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> context.sql("SELECT z FROM (VALUES (1, 2), (3, 4)) AS t (x, y)").join(),
+          "invalid column name in query should raise an error");
+    }
+  }
+
   private static void testQuery(SessionContext context, BufferAllocator allocator)
       throws Exception {
     try (ArrowReader reader =

--- a/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestSessionConfig.java
+++ b/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestSessionConfig.java
@@ -1,0 +1,31 @@
+package org.apache.arrow.datafusion;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestSessionConfig {
+  @Test
+  public void testRegisterInvalidCsvPath(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create()) {
+      Path filePath = tempDir.resolve("non-existent.csv");
+      assertThrows(
+          RuntimeException.class,
+          () -> context.registerCsv("test", filePath).join(),
+          "Expected an exception to be raised from an IO error");
+    }
+  }
+
+  @Test
+  public void testRegisterInvalidParquetPath(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create()) {
+      Path filePath = tempDir.resolve("non-existent.parquet");
+      assertThrows(
+          RuntimeException.class,
+          () -> context.registerParquet("test", filePath).join(),
+          "Expected an exception to be raised from an IO error");
+    }
+  }
+}

--- a/datafusion-jni/src/lib.rs
+++ b/datafusion-jni/src/lib.rs
@@ -3,3 +3,4 @@ mod dataframe;
 mod runtime;
 mod stream;
 mod table_provider;
+mod util;

--- a/datafusion-jni/src/util.rs
+++ b/datafusion-jni/src/util.rs
@@ -15,7 +15,7 @@ pub fn set_error_message<Err: Error>(env: &mut JNIEnv, callback: JObject, result
                 "(Ljava/lang/Object;)V",
                 &[(&err_message).into()],
             )
-            .expect("Failed to call error handler with null");
+            .expect("Failed to call error handler with null message");
         }
         Err(err) => {
             let err_message = env
@@ -27,7 +27,7 @@ pub fn set_error_message<Err: Error>(env: &mut JNIEnv, callback: JObject, result
                 "(Ljava/lang/Object;)V",
                 &[(&err_message).into()],
             )
-            .expect("Failed to call error handler with null");
+            .expect("Failed to call error handler with error message");
         }
     };
 }

--- a/datafusion-jni/src/util.rs
+++ b/datafusion-jni/src/util.rs
@@ -1,0 +1,72 @@
+use std::error::Error;
+
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni::JNIEnv;
+
+/// Set error message from a result using a Consumer<String> Java callback
+pub fn set_error_message<Err: Error>(env: &mut JNIEnv, callback: JObject, result: Result<(), Err>) {
+    match result {
+        Ok(_) => {
+            let err_message = JObject::null();
+            env.call_method(
+                callback,
+                "accept",
+                "(Ljava/lang/Object;)V",
+                &[(&err_message).into()],
+            )
+            .expect("Failed to call error handler with null");
+        }
+        Err(err) => {
+            let err_message = env
+                .new_string(err.to_string())
+                .expect("Couldn't create java string for error message");
+            env.call_method(
+                callback,
+                "accept",
+                "(Ljava/lang/Object;)V",
+                &[(&err_message).into()],
+            )
+            .expect("Failed to call error handler with null");
+        }
+    };
+}
+
+/// Call an ObjectResultCallback to return either a pointer to a newly created object or an error message
+pub fn set_object_result<T, Err: Error>(
+    env: &mut JNIEnv,
+    callback: JObject,
+    address: Result<*mut T, Err>,
+) {
+    match address {
+        Ok(address) => set_object_result_ok(env, callback, address),
+        Err(err) => set_object_result_error(env, callback, &err),
+    };
+}
+
+/// Set success result by calling an ObjectResultCallback
+pub fn set_object_result_ok<T>(env: &mut JNIEnv, callback: JObject, address: *mut T) {
+    let err_message = JObject::null();
+    env.call_method(
+        callback,
+        "callback",
+        "(Ljava/lang/String;J)V",
+        &[(&err_message).into(), (address as jlong).into()],
+    )
+    .expect("Failed to call object result callback with address");
+}
+
+/// Set error result by calling an ObjectResultCallback
+pub fn set_object_result_error<T: Error>(env: &mut JNIEnv, callback: JObject, error: &T) {
+    let err_message = env
+        .new_string(error.to_string())
+        .expect("Couldn't create java string for error message");
+    let address = -1 as jlong;
+    env.call_method(
+        callback,
+        "callback",
+        "(Ljava/lang/String;J)V",
+        &[(&err_message).into(), address.into()],
+    )
+    .expect("Failed to call object result callback with error");
+}


### PR DESCRIPTION
This is just a small tidy up to reduce some duplication of logic for handling errors and calling Java callbacks.

I've got some more features I'd like to add (supporting listing tables and configuration options) but thought this should be its own pull request before adding these.