### PR TITLE
Fix dependencies missing from pom.xml

### DIFF
--- a/datafusion-java/build.gradle
+++ b/datafusion-java/build.gradle
@@ -8,9 +8,9 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'org.apache.arrow:arrow-format:13.0.0'
-    implementation 'org.apache.arrow:arrow-vector:13.0.0'
+    api 'org.slf4j:slf4j-api:1.7.36'
+    api 'org.apache.arrow:arrow-format:13.0.0'
+    api 'org.apache.arrow:arrow-vector:13.0.0'
     implementation 'org.apache.arrow:arrow-c-data:13.0.0'
     runtimeOnly 'org.apache.arrow:arrow-memory-unsafe:13.0.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
@@ -152,6 +152,39 @@ publishing {
                     connection = 'scm:git:git@github.com:datafusion-contrib/datafusion-java.git'
                     developerConnection = 'scm:git:https://github.com/datafusion-contrib/datafusion-java.git'
                     url = 'https://github.com/datafusion-contrib/datafusion-java'
+                }
+            }
+            pom.withXml {
+                // Dependencies don't get mapped to the pom file due to using custom artifacts,
+                // so add them here
+                def dependenciesNode = asNode().appendNode('dependencies')
+                def apiDependencies = configurations.api.allDependencies
+                Set<String> includedDependencies = []
+                apiDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.getGroup())
+                    dependencyNode.appendNode('artifactId', it.getName())
+                    dependencyNode.appendNode('version', it.getVersion())
+                    dependencyNode.appendNode('scope', 'compile')
+                    includedDependencies.add(String.format("%s:%s", it.getGroup(), it.getName()))
+                }
+                def implementationDependencies = configurations.implementation.allDependencies
+                implementationDependencies.each {
+                    if (!includedDependencies.contains(String.format("%s:%s", it.getGroup(), it.getName()))) {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.getGroup())
+                        dependencyNode.appendNode('artifactId', it.getName())
+                        dependencyNode.appendNode('version', it.getVersion())
+                        dependencyNode.appendNode('scope', 'runtime')
+                    }
+                }
+                def runtimeDependencies = configurations.runtimeOnly.allDependencies
+                runtimeDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.getGroup())
+                    dependencyNode.appendNode('artifactId', it.getName())
+                    dependencyNode.appendNode('version', it.getVersion())
+                    dependencyNode.appendNode('scope', 'runtime')
                 }
             }
         }


### PR DESCRIPTION
Because of the way datafusion-java creates custom artifacts, the dependency information isn't automatically included in the generated pom.xml. This can lead to confusion for users when they don't realise they need to install an extra dependency.

This fixes the problem by editing the pom.xml to add the required dependencies.

The generated dependencies look like:
```xml
  <dependencies>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.36</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.arrow</groupId>
      <artifactId>arrow-format</artifactId>
      <version>13.0.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.arrow</groupId>
      <artifactId>arrow-vector</artifactId>
      <version>13.0.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.arrow</groupId>
      <artifactId>arrow-c-data</artifactId>
      <version>13.0.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.arrow</groupId>
      <artifactId>arrow-memory-unsafe</artifactId>
      <version>13.0.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>

```