### PR TITLE
Add support for listing tables

### DIFF
--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/AbstractProxy.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/AbstractProxy.java
@@ -21,6 +21,11 @@ abstract class AbstractProxy implements AutoCloseable, NativeProxy {
     this.children = new ConcurrentHashMap<>();
   }
 
+  /**
+   * Register a child proxy object that should be closed when this object is closed
+   *
+   * @param child the child proxy to register
+   */
   protected final void registerChild(AbstractProxy child) {
     AbstractProxy old = children.putIfAbsent(child.getPointer(), child);
     if (old != null) {
@@ -28,6 +33,9 @@ abstract class AbstractProxy implements AutoCloseable, NativeProxy {
     }
   }
 
+  /**
+   * @return Whether the object has been closed
+   */
   protected final boolean isClosed() {
     return closed.get();
   }

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/CsvFormat.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/CsvFormat.java
@@ -1,0 +1,14 @@
+package org.apache.arrow.datafusion;
+
+/** The CSV file format configuration */
+public class CsvFormat extends AbstractProxy implements FileFormat {
+  /** Create new CSV format with default options */
+  public CsvFormat() {
+    super(FileFormats.createCsv());
+  }
+
+  @Override
+  void doClose(long pointer) {
+    FileFormats.destroyFileFormat(pointer);
+  }
+}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/DefaultDataFrame.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/DefaultDataFrame.java
@@ -29,7 +29,7 @@ class DefaultDataFrame extends AbstractProxy implements DataFrame {
         runtimePointer,
         dataframe,
         (String errString, byte[] arr) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             result.completeExceptionally(new RuntimeException(errString));
           } else {
             logger.info("successfully completed with arr length={}", arr.length);
@@ -51,17 +51,13 @@ class DefaultDataFrame extends AbstractProxy implements DataFrame {
         runtimePointer,
         dataframe,
         (errString, streamId) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             result.completeExceptionally(new RuntimeException(errString));
           } else {
             result.complete(new DefaultRecordBatchStream(context, streamId, allocator));
           }
         });
     return result;
-  }
-
-  private boolean containsError(String errString) {
-    return errString != null && !errString.isEmpty();
   }
 
   @Override
@@ -74,7 +70,7 @@ class DefaultDataFrame extends AbstractProxy implements DataFrame {
         runtimePointer,
         dataframe,
         (String errString) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             future.completeExceptionally(new RuntimeException(errString));
           } else {
             future.complete(null);
@@ -94,7 +90,7 @@ class DefaultDataFrame extends AbstractProxy implements DataFrame {
         dataframe,
         path.toAbsolutePath().toString(),
         (String errString) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             future.completeExceptionally(new RuntimeException(errString));
           } else {
             future.complete(null);
@@ -114,7 +110,7 @@ class DefaultDataFrame extends AbstractProxy implements DataFrame {
         dataframe,
         path.toAbsolutePath().toString(),
         (String errString) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             future.completeExceptionally(new RuntimeException(errString));
           } else {
             future.complete(null);

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/DefaultRecordBatchStream.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/DefaultRecordBatchStream.java
@@ -51,7 +51,7 @@ class DefaultRecordBatchStream extends AbstractProxy implements RecordBatchStrea
         runtimePointer,
         recordBatchStream,
         (errString, arrowArrayAddress) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             result.completeExceptionally(new RuntimeException(errString));
           } else if (arrowArrayAddress == 0) {
             // Reached end of stream
@@ -95,7 +95,7 @@ class DefaultRecordBatchStream extends AbstractProxy implements RecordBatchStrea
     getSchema(
         recordBatchStream,
         (errString, arrowSchemaAddress) -> {
-          if (containsError(errString)) {
+          if (ErrorUtil.containsError(errString)) {
             result.completeExceptionally(new RuntimeException(errString));
           } else {
             try {
@@ -109,10 +109,6 @@ class DefaultRecordBatchStream extends AbstractProxy implements RecordBatchStrea
           }
         });
     return result.join();
-  }
-
-  private static boolean containsError(String errString) {
-    return errString != null && !"".equals(errString);
   }
 
   private static native void getSchema(long pointer, ObjectResultCallback callback);

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/ErrorUtil.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/ErrorUtil.java
@@ -1,0 +1,10 @@
+package org.apache.arrow.datafusion;
+
+class ErrorUtil {
+
+  private ErrorUtil() {}
+
+  static boolean containsError(String errString) {
+    return errString != null && !errString.isEmpty();
+  }
+}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/FileFormat.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/FileFormat.java
@@ -1,0 +1,4 @@
+package org.apache.arrow.datafusion;
+
+/** Interface for file formats that can provide table data */
+public interface FileFormat extends AutoCloseable, NativeProxy {}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/FileFormats.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/FileFormats.java
@@ -1,0 +1,12 @@
+package org.apache.arrow.datafusion;
+
+class FileFormats {
+
+  private FileFormats() {}
+
+  static native long createCsv();
+
+  static native long createParquet();
+
+  static native void destroyFileFormat(long pointer);
+}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/ListingOptions.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/ListingOptions.java
@@ -1,0 +1,79 @@
+package org.apache.arrow.datafusion;
+
+/** Configures options for a {@link ListingTable} */
+public class ListingOptions extends AbstractProxy implements AutoCloseable {
+  /** A Builder for {@link ListingOptions} instances */
+  public static class Builder {
+    private final FileFormat format;
+    private String fileExtension = "";
+    private boolean collectStat = true;
+
+    /**
+     * Create a new {@link ListingOptions} builder
+     *
+     * @param format The file format used by data files in the listing table
+     */
+    public Builder(FileFormat format) {
+      this.format = format;
+    }
+
+    /**
+     * Specify a suffix used to filter files in the listing location
+     *
+     * @param fileExtension The file suffix to filter on
+     * @return This builder
+     */
+    public Builder withFileExtension(String fileExtension) {
+      this.fileExtension = fileExtension;
+      return this;
+    }
+
+    /**
+     * Specify whether to collect statistics from files
+     *
+     * @param collectStat whether to collect statistics
+     * @return This builder
+     */
+    public Builder withCollectStat(boolean collectStat) {
+      this.collectStat = collectStat;
+      return this;
+    }
+
+    /**
+     * Build a new {@link ListingOptions} instance from the configured builder
+     *
+     * @return The built {@link ListingOptions}
+     */
+    public ListingOptions build() {
+      return new ListingOptions(this);
+    }
+  }
+
+  /**
+   * Create a builder for listing options
+   *
+   * @param format The file format used by data files in the listing table
+   * @return A new {@link Builder} instance
+   */
+  public static Builder builder(FileFormat format) {
+    return new Builder(format);
+  }
+
+  /**
+   * Construct ListingOptions from a Builder
+   *
+   * @param builder The builder to use
+   */
+  private ListingOptions(Builder builder) {
+    super(create(builder.format.getPointer(), builder.fileExtension, builder.collectStat));
+  }
+
+  @Override
+  void doClose(long pointer) {
+    destroy(pointer);
+  }
+
+  private static native long create(long format, String fileExtension, boolean collectStat);
+
+  private static native void destroy(long pointer);
+}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/ListingTable.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/ListingTable.java
@@ -1,0 +1,36 @@
+package org.apache.arrow.datafusion;
+
+import java.util.concurrent.CompletableFuture;
+
+/** A data source composed of multiple files that share a schema */
+public class ListingTable extends AbstractProxy implements TableProvider {
+  /**
+   * Create a new listing table
+   *
+   * @param config The listing table configuration
+   */
+  public ListingTable(ListingTableConfig config) {
+    super(createListingTable(config));
+  }
+
+  private static long createListingTable(ListingTableConfig config) {
+    CompletableFuture<Long> result = new CompletableFuture<>();
+    create(
+        config.getPointer(),
+        (errString, tableId) -> {
+          if (ErrorUtil.containsError(errString)) {
+            result.completeExceptionally(new RuntimeException(errString));
+          } else {
+            result.complete(tableId);
+          }
+        });
+    return result.join();
+  }
+
+  @Override
+  void doClose(long pointer) {
+    TableProviders.destroyTableProvider(pointer);
+  }
+
+  private static native void create(long config, ObjectResultCallback result);
+}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/ListingTableConfig.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/ListingTableConfig.java
@@ -1,0 +1,136 @@
+package org.apache.arrow.datafusion;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+/** Configuration for creating a {@link ListingTable} */
+public class ListingTableConfig extends AbstractProxy implements AutoCloseable {
+  /** A Builder for {@link ListingTableConfig} instances */
+  public static class Builder {
+    private final String[] tablePaths;
+    private ListingOptions options = null;
+
+    /**
+     * Create a new {@link Builder}
+     *
+     * @param tablePath The path where data files are stored. This may be a file system path or a
+     *     URL with a scheme. When no scheme is provided, glob expressions may be used to filter
+     *     files.
+     */
+    public Builder(String tablePath) {
+      this(new String[] {tablePath});
+    }
+
+    /**
+     * Create a new {@link Builder}
+     *
+     * @param tablePaths The paths where data files are stored. This may be an array of file system
+     *     paths or an array of URLs with a scheme. When no scheme is provided, glob expressions may
+     *     be used to filter files.
+     */
+    public Builder(String[] tablePaths) {
+      this.tablePaths = tablePaths;
+    }
+
+    /**
+     * Specify the {@link ListingOptions} to use
+     *
+     * @param options The {@link ListingOptions} to use
+     * @return this Builder instance
+     */
+    public Builder withListingOptions(ListingOptions options) {
+      this.options = options;
+      return this;
+    }
+
+    /**
+     * Create the listing table config. This is async as the schema may need to be inferred
+     *
+     * @param context The {@link SessionContext} to use when inferring the schema
+     * @return Future that will complete with the table config
+     */
+    public CompletableFuture<ListingTableConfig> build(SessionContext context) {
+      return createListingTableConfig(this, context).thenApply(ListingTableConfig::new);
+    }
+  }
+
+  /**
+   * Create a new {@link Builder} for a {@link ListingTableConfig}
+   *
+   * @param tablePath The path where data files are stored. This may be a file system path or a URL
+   *     with a scheme. When no scheme is specified, glob expressions may be used to filter files.
+   * @return A new {@link Builder} instance
+   */
+  public static Builder builder(String tablePath) {
+    return new Builder(tablePath);
+  }
+
+  /**
+   * Create a new {@link Builder} for a {@link ListingTableConfig} from a file path
+   *
+   * @param tablePath The path where data files are stored
+   * @return A new {@link Builder} instance
+   */
+  public static Builder builder(Path tablePath) {
+    return new Builder(tablePath.toString());
+  }
+
+  /**
+   * Create a new {@link Builder} for a {@link ListingTableConfig} from an array of paths
+   *
+   * @param tablePaths The path array where data files are stored
+   * @return A new {@link Builder} instance
+   */
+  public static Builder builder(Path[] tablePaths) {
+    String[] pathStrings =
+        Arrays.stream(tablePaths)
+            .map(path -> path.toString())
+            .toArray(length -> new String[length]);
+    return new Builder(pathStrings);
+  }
+
+  /**
+   * Create a new {@link Builder} for a {@link ListingTableConfig} from a URI
+   *
+   * @param tablePath The location where data files are stored
+   * @return A new {@link Builder} instance
+   */
+  public static Builder builder(URI tablePath) {
+    return new Builder(tablePath.toString());
+  }
+
+  private ListingTableConfig(long pointer) {
+    super(pointer);
+  }
+
+  private static CompletableFuture<Long> createListingTableConfig(
+      Builder builder, SessionContext context) {
+    CompletableFuture<Long> future = new CompletableFuture<>();
+    Runtime runtime = context.getRuntime();
+    create(
+        runtime.getPointer(),
+        context.getPointer(),
+        builder.tablePaths,
+        builder.options == null ? 0 : builder.options.getPointer(),
+        (errMessage, configId) -> {
+          if (ErrorUtil.containsError(errMessage)) {
+            future.completeExceptionally(new RuntimeException(errMessage));
+          } else {
+            future.complete(configId);
+          }
+        });
+    return future;
+  }
+
+  @Override
+  void doClose(long pointer) {
+    destroy(pointer);
+  }
+
+  private static native void create(
+      long runtime, long context, String[] tablePaths, long options, ObjectResultCallback callback);
+
+  private static native void destroy(long pointer);
+}

--- a/datafusion-java/src/main/java/org/apache/arrow/datafusion/ParquetFormat.java
+++ b/datafusion-java/src/main/java/org/apache/arrow/datafusion/ParquetFormat.java
@@ -1,0 +1,14 @@
+package org.apache.arrow.datafusion;
+
+/** The Apache Parquet file format configuration */
+public class ParquetFormat extends AbstractProxy implements FileFormat {
+  /** Create new ParquetFormat with default options */
+  public ParquetFormat() {
+    super(FileFormats.createParquet());
+  }
+
+  @Override
+  void doClose(long pointer) {
+    FileFormats.destroyFileFormat(pointer);
+  }
+}

--- a/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestListingTable.java
+++ b/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestListingTable.java
@@ -1,0 +1,261 @@
+package org.apache.arrow.datafusion;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestListingTable {
+  @Test
+  public void testCsvListingTable(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path dataDir = tempDir.resolve("data");
+      Files.createDirectories(dataDir);
+
+      Path csvFilePath0 = dataDir.resolve("0.csv");
+      List<String> lines = Arrays.asList("x,y", "1,2", "3,4");
+      Files.write(csvFilePath0, lines);
+
+      Path csvFilePath1 = dataDir.resolve("1.csv");
+      lines = Arrays.asList("x,y", "1,12", "3,14");
+      Files.write(csvFilePath1, lines);
+
+      try (CsvFormat format = new CsvFormat();
+          ListingOptions listingOptions =
+              ListingOptions.builder(format).withFileExtension(".csv").build();
+          ListingTableConfig tableConfig =
+              ListingTableConfig.builder(dataDir)
+                  .withListingOptions(listingOptions)
+                  .build(context)
+                  .join();
+          ListingTable listingTable = new ListingTable(tableConfig)) {
+        context.registerTable("test", listingTable);
+        testQuery(context, allocator);
+      }
+    }
+  }
+
+  @Test
+  public void testParquetListingTable(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path dataDir = tempDir.resolve("data");
+      writeParquetFiles(dataDir);
+
+      try (ParquetFormat format = new ParquetFormat();
+          ListingOptions listingOptions =
+              ListingOptions.builder(format).withFileExtension(".parquet").build();
+          ListingTableConfig tableConfig =
+              ListingTableConfig.builder(dataDir)
+                  .withListingOptions(listingOptions)
+                  .build(context)
+                  .join();
+          ListingTable listingTable = new ListingTable(tableConfig)) {
+        context.registerTable("test", listingTable);
+        testQuery(context, allocator);
+      }
+    }
+  }
+
+  @Test
+  public void testDisableCollectStat(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path dataDir = tempDir.resolve("data");
+      writeParquetFiles(dataDir);
+
+      try (ParquetFormat format = new ParquetFormat();
+          ListingOptions listingOptions =
+              ListingOptions.builder(format)
+                  .withFileExtension(".parquet")
+                  .withCollectStat(false)
+                  .build();
+          ListingTableConfig tableConfig =
+              ListingTableConfig.builder(dataDir)
+                  .withListingOptions(listingOptions)
+                  .build(context)
+                  .join();
+          ListingTable listingTable = new ListingTable(tableConfig)) {
+        context.registerTable("test", listingTable);
+        testQuery(context, allocator);
+      }
+    }
+  }
+
+  @Test
+  public void testMultiplePaths(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path dataDir = tempDir.resolve("data");
+      Path[] dataFiles = writeParquetFiles(dataDir);
+
+      try (ParquetFormat format = new ParquetFormat();
+          ListingOptions listingOptions =
+              ListingOptions.builder(format).withFileExtension(".parquet").build();
+          ListingTableConfig tableConfig =
+              ListingTableConfig.builder(dataFiles)
+                  .withListingOptions(listingOptions)
+                  .build(context)
+                  .join();
+          ListingTable listingTable = new ListingTable(tableConfig)) {
+        context.registerTable("test", listingTable);
+        testQuery(context, allocator);
+      }
+    }
+  }
+
+  private static Path[] writeParquetFiles(Path dataDir) throws Exception {
+    String schema =
+        "{\"namespace\": \"org.example\","
+            + "\"type\": \"record\","
+            + "\"name\": \"record_name\","
+            + "\"fields\": ["
+            + " {\"name\": \"x\", \"type\": \"long\"},"
+            + " {\"name\": \"y\", \"type\": \"long\"}"
+            + " ]}";
+
+    Path parquetFilePath0 = dataDir.resolve("0.parquet");
+    ParquetWriter.writeParquet(
+        parquetFilePath0,
+        schema,
+        2,
+        (i, record) -> {
+          record.put("x", i * 2 + 1);
+          record.put("y", i * 2 + 2);
+        });
+
+    Path parquetFilePath1 = dataDir.resolve("1.parquet");
+    ParquetWriter.writeParquet(
+        parquetFilePath1,
+        schema,
+        2,
+        (i, record) -> {
+          record.put("x", i * 2 + 1);
+          record.put("y", i * 2 + 12);
+        });
+    return new Path[] {parquetFilePath0, parquetFilePath1};
+  }
+
+  private static void testQuery(SessionContext context, BufferAllocator allocator)
+      throws Exception {
+    try (ArrowReader reader =
+        context
+            .sql("SELECT y FROM test WHERE x = 3 ORDER BY y")
+            .thenComposeAsync(df -> df.collect(allocator))
+            .join()) {
+
+      long[] expectedResults = {4, 14};
+      int globalRow = 0;
+      VectorSchemaRoot root = reader.getVectorSchemaRoot();
+      while (reader.loadNextBatch()) {
+        BigIntVector yValues = (BigIntVector) root.getVector(0);
+        for (int row = 0; row < root.getRowCount(); ++row, ++globalRow) {
+          assertTrue(globalRow < expectedResults.length);
+          assertEquals(expectedResults[globalRow], yValues.get(row));
+        }
+      }
+      assertEquals(expectedResults.length, globalRow);
+    }
+  }
+
+  @Test
+  public void testParquetTimestampedStrings(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path dataDir = tempDir.resolve("data");
+      String schema =
+          "{\"namespace\": \"org.example\","
+              + "\"type\": \"record\","
+              + "\"name\": \"record_name\","
+              + "\"fields\": ["
+              + " {\"name\": \"id\", \"type\": \"long\"},"
+              + " {\"name\": \"timestamp\", \"type\": {\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}},"
+              + " {\"name\": \"text\", \"type\": \"string\"}"
+              + " ]}";
+
+      Path parquetFilePath0 = dataDir.resolve("0.parquet");
+      Instant[] timestamps0 = {
+        Instant.parse("2022-04-04T00:00:00Z"),
+        Instant.parse("2022-05-04T00:00:00Z"),
+        Instant.parse("2022-06-06T00:00:00Z"),
+      };
+      ParquetWriter.writeParquet(
+          parquetFilePath0,
+          schema,
+          3,
+          (i, record) -> {
+            record.put("id", i + 1);
+            record.put("timestamp", (timestamps0[i].getEpochSecond() * 1_000));
+            record.put("text", String.format("Text%d", i + 1));
+          });
+
+      Path parquetFilePath1 = dataDir.resolve("1.parquet");
+      Instant[] timestamps1 = {
+        Instant.parse("2023-04-04T00:00:00Z"),
+        Instant.parse("2023-04-04T00:00:00Z"),
+        Instant.parse("2022-08-01T00:00:00Z"),
+      };
+      ParquetWriter.writeParquet(
+          parquetFilePath1,
+          schema,
+          3,
+          (i, record) -> {
+            record.put("id", i + 4);
+            record.put("timestamp", (timestamps1[i].getEpochSecond() * 1_000));
+            record.put("text", String.format("Text%d", i + 4));
+          });
+
+      Path[] filePaths = {parquetFilePath0, parquetFilePath1};
+
+      try (ParquetFormat format = new ParquetFormat();
+          ListingOptions listingOptions =
+              ListingOptions.builder(format).withFileExtension(".parquet").build();
+          ListingTableConfig tableConfig =
+              ListingTableConfig.builder(filePaths)
+                  .withListingOptions(listingOptions)
+                  .build(context)
+                  .join();
+          ListingTable listingTable = new ListingTable(tableConfig)) {
+        context.registerTable("test", listingTable);
+        try (ArrowReader reader =
+            context
+                .sql(
+                    "SELECT id,text FROM test WHERE ID IN (2, 3, 4) AND timestamp < '2023-01-01T00:00:00Z' ORDER BY id")
+                .thenComposeAsync(df -> df.collect(allocator))
+                .join()) {
+
+          Long[] expectedIds = {2L, 3L};
+          String[] expectedText = {"Text2", "Text3"};
+          List<Long> actualIds = new ArrayList<>();
+          List<String> actualText = new ArrayList<>();
+          int globalRow = 0;
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          while (reader.loadNextBatch()) {
+            BigIntVector idValues = (BigIntVector) root.getVector(0);
+            VarCharVector textValues = (VarCharVector) root.getVector(1);
+            for (int row = 0; row < root.getRowCount(); ++row, ++globalRow) {
+              actualIds.add(idValues.get(row));
+              actualText.add(new String(textValues.get(row), StandardCharsets.UTF_8));
+            }
+          }
+          assertArrayEquals(expectedIds, actualIds.toArray(new Long[0]));
+          assertArrayEquals(expectedText, actualText.toArray(new String[0]));
+        }
+      }
+    }
+  }
+}

--- a/datafusion-jni/src/file_formats.rs
+++ b/datafusion-jni/src/file_formats.rs
@@ -1,0 +1,38 @@
+use datafusion::datasource::file_format::csv::CsvFormat;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::file_format::FileFormat;
+use jni::objects::JClass;
+use jni::sys::jlong;
+use jni::JNIEnv;
+use std::sync::Arc;
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_FileFormats_createCsv(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jlong {
+    // Return as an Arc<dyn FileFormat> rather than CsvFormat so this
+    // can be passed into ListingOptions.create
+    let format: Arc<dyn FileFormat> = Arc::new(CsvFormat::default());
+    Box::into_raw(Box::new(format)) as jlong
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_FileFormats_createParquet(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jlong {
+    // Return as an Arc<dyn FileFormat> rather than ParquetFormat so this
+    // can be passed into ListingOptions.create
+    let format: Arc<dyn FileFormat> = Arc::new(ParquetFormat::default());
+    Box::into_raw(Box::new(format)) as jlong
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_FileFormats_destroyFileFormat(
+    _env: JNIEnv,
+    _class: JClass,
+    pointer: jlong,
+) {
+    let _ = unsafe { Box::from_raw(pointer as *mut Arc<dyn FileFormat>) };
+}

--- a/datafusion-jni/src/lib.rs
+++ b/datafusion-jni/src/lib.rs
@@ -1,5 +1,9 @@
 mod context;
 mod dataframe;
+mod file_formats;
+mod listing_options;
+mod listing_table;
+mod listing_table_config;
 mod runtime;
 mod stream;
 mod table_provider;

--- a/datafusion-jni/src/listing_options.rs
+++ b/datafusion-jni/src/listing_options.rs
@@ -1,0 +1,36 @@
+use datafusion::datasource::file_format::FileFormat;
+use datafusion::datasource::listing::ListingOptions;
+use jni::objects::{JClass, JString};
+use jni::sys::{jboolean, jlong};
+use jni::JNIEnv;
+use std::sync::Arc;
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_ListingOptions_create(
+    mut env: JNIEnv,
+    _class: JClass,
+    format: jlong,
+    file_extension: JString,
+    collect_stat: jboolean,
+) -> jlong {
+    let format = unsafe { &*(format as *const Arc<dyn FileFormat>) };
+
+    let file_extension: String = env
+        .get_string(&file_extension)
+        .expect("Couldn't get Java file_extension string")
+        .into();
+
+    let listing_options = ListingOptions::new(format.clone())
+        .with_file_extension(file_extension)
+        .with_collect_stat(collect_stat == 1u8);
+    Box::into_raw(Box::new(listing_options)) as jlong
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_ListingOptions_destroy(
+    _env: JNIEnv,
+    _class: JClass,
+    pointer: jlong,
+) {
+    let _ = unsafe { Box::from_raw(pointer as *mut ListingOptions) };
+}

--- a/datafusion-jni/src/listing_table.rs
+++ b/datafusion-jni/src/listing_table.rs
@@ -1,0 +1,31 @@
+use datafusion::datasource::listing::{ListingTable, ListingTableConfig};
+use datafusion::datasource::TableProvider;
+use jni::objects::{JClass, JObject};
+use jni::sys::jlong;
+use jni::JNIEnv;
+use std::sync::Arc;
+
+use crate::util::set_object_result;
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_ListingTable_create(
+    mut env: JNIEnv,
+    _class: JClass,
+    table_config: jlong,
+    object_result: JObject,
+) {
+    let table_config = unsafe { &*(table_config as *const ListingTableConfig) };
+    // Clone table config as it will be moved into ListingTable
+    let table_config = ListingTableConfig {
+        table_paths: table_config.table_paths.clone(),
+        file_schema: table_config.file_schema.clone(),
+        options: table_config.options.clone(),
+    };
+    let table_provider_result = ListingTable::try_new(table_config).map(|listing_table| {
+        // Return as an Arc<dyn TableProvider> rather than ListingTable so this
+        // can be passed into SessionContext.registerTable
+        let table_provider: Arc<dyn TableProvider> = Arc::new(listing_table);
+        Box::into_raw(Box::new(table_provider))
+    });
+    set_object_result(&mut env, object_result, table_provider_result);
+}

--- a/datafusion-jni/src/listing_table_config.rs
+++ b/datafusion-jni/src/listing_table_config.rs
@@ -1,0 +1,75 @@
+use datafusion::datasource::listing::{ListingOptions, ListingTableConfig, ListingTableUrl};
+use datafusion::execution::context::SessionContext;
+use jni::objects::{JClass, JObject, JObjectArray, JString};
+use jni::sys::jlong;
+use jni::JNIEnv;
+use tokio::runtime::Runtime;
+
+use crate::util::{set_object_result, set_object_result_error};
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_ListingTableConfig_create(
+    mut env: JNIEnv,
+    _class: JClass,
+    runtime: jlong,
+    context: jlong,
+    table_paths: JObjectArray,
+    listing_options: jlong,
+    callback: JObject,
+) {
+    let runtime = unsafe { &*(runtime as *const Runtime) };
+    let context = unsafe { &*(context as *const SessionContext) };
+
+    let mut table_urls: Vec<ListingTableUrl> = Vec::new();
+    let table_paths_length = env
+        .get_array_length(&table_paths)
+        .expect("Couldn't get array length of table_paths");
+    for i in 0..table_paths_length {
+        let table_path_str: JString = env
+            .get_object_array_element(&table_paths, i)
+            .expect("Couldn't get array string element")
+            .into();
+        let table_path: String = env
+            .get_string(&table_path_str)
+            .expect("Couldn't get native string source")
+            .into();
+        let table_url = ListingTableUrl::parse(table_path);
+        let table_url = match table_url {
+            Ok(url) => url,
+            Err(err) => {
+                set_object_result_error(&mut env, callback, &err);
+                return;
+            }
+        };
+        table_urls.push(table_url);
+    }
+
+    runtime.block_on(async {
+        let listing_table_config = ListingTableConfig::new_with_multi_paths(table_urls);
+
+        let listing_table_config = match listing_options {
+            0 => listing_table_config,
+            listing_options => {
+                let listing_options = unsafe { &*(listing_options as *const ListingOptions) };
+                listing_table_config.with_listing_options(listing_options.clone())
+            }
+        };
+
+        let session_state = context.state();
+        let config_result = listing_table_config.infer_schema(&session_state).await;
+        set_object_result(
+            &mut env,
+            callback,
+            config_result.map(|config| Box::into_raw(Box::new(config))),
+        );
+    });
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_arrow_datafusion_ListingTableConfig_destroy(
+    _env: JNIEnv,
+    _class: JClass,
+    pointer: jlong,
+) {
+    let _ = unsafe { Box::from_raw(pointer as *mut ListingTableConfig) };
+}


### PR DESCRIPTION
This adds support for using listing tables that are made of multiple parquet or CSV files. I haven't implemented all possible configuration options but these could easily be added later as needed.

I'd also like to add support for Arrow IPC files (aka feather files) but that requires upgrading datafusion to >= 25 so I'll save that for another PR.