### PR TITLE
fix: Test build task depends on copyDevLibrary

### DIFF
--- a/datafusion-java/build.gradle
+++ b/datafusion-java/build.gradle
@@ -75,6 +75,10 @@ tasks.register('copyDevLibrary', Sync) {
     dependsOn cargoDevBuild
 }
 
+tasks.named("test") {
+    dependsOn copyDevLibrary
+}
+
 tasks.register('copyBuiltLibrary', Copy) {
     def extension = extensionMapping[osdetector.os]
     from "${rootDir}/datafusion-jni/target/release/libdatafusion_jni.$extension"


### PR DESCRIPTION
Running `./gradlew build` on a clean checkout was failing, because the `test` task was running before the native library was built + copied.